### PR TITLE
Allow logging to be turned off

### DIFF
--- a/classes/debug.php
+++ b/classes/debug.php
@@ -63,8 +63,8 @@ class SyncDebug
 	 */
 	public static function log($msg = NULL, $backtrace = FALSE)
 	{
-//		if (!self::$_debug && !defined('WP_DEBUG') || !WP_DEBUG)
-//			return;
+		if (!self::$_debug && !defined('WP_DEBUG') || !WP_DEBUG)
+			return;
 
 		if (self::$_debug_output)
 			echo $msg, PHP_EOL;


### PR DESCRIPTION
Even with WP_DEBUG set to false, the plugin was still writing to ~log.txt. Seems like this is a security issue given that it writes authorization tokens to the log. I uncommented the code that was probably commented out during development.