### PR TITLE
fix bug with $offset going out of sync if content is modified by filter

### DIFF
--- a/classes/apicontroller.php
+++ b/classes/apicontroller.php
@@ -287,6 +287,7 @@ SyncDebug::log(__METHOD__.'():' . __LINE__ . ' response has no errors');
 	 */
 	public function push(SyncApiResponse $response)
 	{
+		global $wpdb;
 SyncDebug::log(__METHOD__.'():'.__LINE__);
 SyncDebug::log(' post data: ' . var_export($_POST, TRUE));
 //SyncDebug::log(' request data: ' . var_export($_REQUEST, TRUE));
@@ -415,6 +416,12 @@ SyncDebug::log(__METHOD__.'():' . __LINE__ . ' content: ' . $post_data['post_con
 				if (is_wp_error($res)) {
 SyncDebug::log(__METHOD__.'():' . __LINE__ . ' error in wp_update_post() ' . $res->get_error_message());
 					$response->error_code(SyncApiRequest::ERROR_CONTENT_UPDATE_FAILED, $res->get_error_message());
+				} else {
+					// also update the date modified
+					$wpdb->update( $wpdb->posts, array(
+						'post_modified'=>$post_data['post_modified'],
+						'post_modified_gmt' => $post_data['post_modified_gmt']),
+						array('ID'=>$post_data['ID']));
 				}
 			} else {
 				$response->error_code(SyncApiRequest::ERROR_NO_PERMISSION);

--- a/classes/apicontroller.php
+++ b/classes/apicontroller.php
@@ -948,6 +948,8 @@ SyncDebug::log(__METHOD__.'():' . __LINE__ . ' source ref id (' . $source_ref_id
 SyncDebug::log(__METHOD__.'():' . __LINE__ . ' unrecognized block type "' . $block_name . '" - sending through filter');
 								// give others a chance to process this block
 								$new_content = apply_filters('spectrom_sync_process_gutenberg_block', $content, $block_name, $json, $target_post_id, $start, $end, $pos);
+								// have to guess at new length of json object based on difference between old and new content
+								$new_obj_len = strlen($json) + (strlen($new_content) - strlen($content));
 								if ($content !== $new_content) {		// check to see if add-ons made any modifications
 									$content = $new_content;
 									$updated = TRUE;


### PR DESCRIPTION
I noticed an issue where if the filter spectrom_sync_process_gutenberg_block changes the block content then the $offset variable may be go out of sync which can cause it to skip the next block. To fix this I added the line after it which guesses the new length of the gutenberg block's json.

Of course the problem with this is that in theory the filter could have made a change to a different block than the one passed in but assuming the filter only makes a change to the current block's json it should be ok.